### PR TITLE
fixing named version

### DIFF
--- a/src/Http/Controllers/NovaInstalledVersionController.php
+++ b/src/Http/Controllers/NovaInstalledVersionController.php
@@ -9,6 +9,6 @@ class NovaInstalledVersionController extends Controller
 {
     public function __invoke()
     {
-        return response()->json(['installed_version' => Nova::version()]);
+        return response()->json(['installed_version' => Str::before(Nova::version(), " ")]);
     }
 }


### PR DESCRIPTION
gives green status on installed version by only comparing before first space.